### PR TITLE
Add utilities tests and improve documentation

### DIFF
--- a/components/utilities.py
+++ b/components/utilities.py
@@ -54,13 +54,17 @@ def coherence(cpsd_matrix : np.ndarray,row_column : Tuple[int] = None ):
         3D array of coherence values where the [i,j,k] entry corresponds to the
         coherence of the CPSD matrix for the ith frequency line, jth row, and
         kth column.
-    
+
     """
     if row_column is None:
+        # Extract the auto-spectral density for each channel along the diagonal
         diag = np.einsum('ijj->ij',cpsd_matrix)
+        # Apply the definition gamma^2 = |G_xy|^2 / (G_xx * G_yy) for every
+        # frequency line and channel pair
         return np.real(np.abs(cpsd_matrix)**2/(diag[:,:,np.newaxis]*diag[:,np.newaxis,:]))
     else:
         row,column = row_column
+        # Compute coherence for just the selected row/column pair
         return np.real(np.abs(cpsd_matrix[:,row,column])**2/(cpsd_matrix[:,row,row]*cpsd_matrix[:,column,column]))
 
 class Channel:
@@ -582,10 +586,12 @@ def db2scale(dB):
         Value in linear
     
     """
-    return 10**(dB/20)
+    return 10**(dB/20)  # Convert decibel value back to a linear scale factor
 
+# Convert a linear power value to decibels
 power2db = lambda power: 10*np.log10(power)
 
+# Convert a linear amplitude (scale factor) to decibels
 scale2db = lambda scale: 20*np.log10(scale)
 
 def rms_time(signal,axis=None,keepdims=False):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,47 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+import numpy as np
+
+# Stub out the qtpy dependency required by components.utilities
+qtpy_stub = types.ModuleType("qtpy")
+qtpy_stub.QtWidgets = types.SimpleNamespace(
+    QMessageBox=types.SimpleNamespace(critical=lambda *args, **kwargs: None)
+)
+sys.modules.setdefault("qtpy", qtpy_stub)
+
+# Dynamically load the utilities module to avoid importing the entire package
+utilities_path = Path(__file__).resolve().parents[1] / "components" / "utilities.py"
+spec = importlib.util.spec_from_file_location("utilities", utilities_path)
+utilities = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utilities)
+
+coherence = utilities.coherence
+db2scale = utilities.db2scale
+scale2db = utilities.scale2db
+rms_time = utilities.rms_time
+
+
+def test_db_scale_conversions():
+    dB = 20.0
+    scale = db2scale(dB)
+    assert np.isclose(scale, 10.0)
+    assert np.isclose(scale2db(scale), dB)
+
+
+def test_coherence_full_matrix_and_single_pair():
+    cpsd = np.zeros((1, 2, 2), dtype=complex)
+    cpsd[0, 0, 0] = 4
+    cpsd[0, 1, 1] = 4
+    cpsd[0, 0, 1] = cpsd[0, 1, 0] = 4
+    coh_full = coherence(cpsd)
+    assert np.allclose(coh_full, np.ones((1, 2, 2)))
+    coh_pair = coherence(cpsd, (0, 1))
+    assert np.allclose(coh_pair, np.ones(1))
+
+
+def test_rms_time():
+    signal = np.array([1, -1, 1, -1])
+    assert np.isclose(rms_time(signal), 1.0)
+    assert np.allclose(rms_time(signal, axis=0), 1.0)


### PR DESCRIPTION
## Summary
- Clarify coherence calculation and decibel conversions with inline comments
- Add unit tests for decibel conversion, coherence, and RMS helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1a69172208323b058a269f1592f8a