### PR TITLE
Fix exception handling in flush_queue

### DIFF
--- a/components/utilities.py
+++ b/components/utilities.py
@@ -564,7 +564,7 @@ def flush_queue(queue,timeout=None):
                 data.append(queue.get('Flush',block = False if timeout is None else True,timeout=timeout))
             else:
                 data.append(queue.get(block = False if timeout is None else True,timeout=timeout))
-        except mp.queues.Empty:
+        except mp_queues.Empty:
             return data
         
 def db2scale(dB):


### PR DESCRIPTION
## Summary
- Fix queue flushing to catch `mp_queues.Empty` when no messages remain

## Testing
- `python -m py_compile components/utilities.py`
- Ran a small multiprocessing script to confirm flushing a queue returns all items


------
https://chatgpt.com/codex/tasks/task_e_68a1a669f5ec8323b2f5594c89323dbe